### PR TITLE
Backport Interpol to Ruby 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 bundler_args: --without extras
 script: "bundle exec rake"
 rvm:
+  - 1.8.7
   - 1.9.2
   - 1.9.3
   - jruby-19mode

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,10 @@ source 'https://rubygems.org'
 gemspec
 
 group :extras do
-  gem 'debugger' if RUBY_ENGINE == 'ruby' && RUBY_VERSION == '1.9.3'
+  gem 'debugger' if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'ruby' && RUBY_VERSION == '1.9.3'
 end
 
-gem 'json-jruby', platform: 'jruby'
-gem 'compass_twitter_bootstrap', git: 'git://github.com/vwall/compass-twitter-bootstrap.git'
+gem 'json-jruby', :platform => 'jruby'
+gem 'compass_twitter_bootstrap', :git => 'git://github.com/vwall/compass-twitter-bootstrap.git'
+
+gem 'json', :platform => 'ruby_18'

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   t.ruby_opts  = "-Ispec -rsimplecov_setup"
 end
 
-if RUBY_ENGINE == 'ruby' # MRI only
+if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'ruby' # MRI only
   require 'cane/rake_task'
 
   desc "Run cane to check quality metrics"
@@ -20,7 +20,7 @@ else
   task(:quality) { } # no-op
 end
 
-task default: [:spec, :quality]
+task :default => [:spec, :quality]
 
 desc "Watch Documentation App Compass Files"
 task :compass_watch do

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -4,5 +4,5 @@ gem 'rspec', '~> 2.9'
 gem 'sinatra', '~> 1.3'
 gem 'rake', '~> 0.9.2.2'
 gem 'multi_json', '~> 1.2.0'
-gem 'interpol', path: '..'
+gem 'interpol', :path => '..'
 

--- a/example/Rakefile
+++ b/example/Rakefile
@@ -12,7 +12,7 @@ Rake::TestTask.new do |t|
   t.test_files = FileList['*_test.rb']
 end
 
-task default: :spec
+task :default => :spec
 
 desc "Boots the stub app"
 task :boot_stub_app do

--- a/lib/interpol/configuration_ruby_18_extensions.rb
+++ b/lib/interpol/configuration_ruby_18_extensions.rb
@@ -1,0 +1,27 @@
+module Interpol
+  module ConfigurationRuby18Extensions
+    def deserialized_hash_from(file)
+      YAML.load(yaml_content_for file).tap do |yaml|
+        if bad_class = bad_deserialized_yaml(yaml)
+          raise ConfigurationError.new \
+            "Received an error while loading YAML from #{file}: \"" +
+            "Got object of type: #{bad_class}\"\n If you are using YAML merge keys " +
+            "to declare shared types, you must configure endpoint_definition_merge_key_files " +
+            "before endpoint_definition_files."
+        end
+      end
+    end
+
+    # returns nil if the YAML has been only partially deserialized by Syck
+    # and there are YAML::Syck objects.
+    def bad_deserialized_yaml(yaml)
+      if [Hash, Array].include? yaml.class
+        yaml.map { |elem| bad_deserialized_yaml(elem) }.compact.first
+      elsif yaml.class.name =~ /YAML::Syck::/
+        yaml.class.name # Bad!
+      else
+        nil
+      end
+    end
+  end
+end

--- a/lib/interpol/documentation.rb
+++ b/lib/interpol/documentation.rb
@@ -32,7 +32,7 @@ module Interpol
 
       def schema_description(doc, schema)
         return unless schema.has_key?('description')
-        doc.h3(class: "description") { doc.text(schema['description']) }
+        doc.h3(:class => "description") { doc.text(schema['description']) }
       end
 
       def render_properties_and_items(doc, schema)
@@ -41,7 +41,7 @@ module Interpol
       end
 
       def schema_definition(doc, schema)
-        doc.div(class: "schema-definition") do
+        doc.div(:class => "schema-definition") do
           schema_description(doc, schema)
           render_properties_and_items(doc, schema)
         end
@@ -50,8 +50,8 @@ module Interpol
       def render_items(doc, items)
         # No support for tuple-typing, just basic array typing
         return  if items.nil?
-        doc.dl(class: "items") do
-          doc.dt(class: "name") { doc.text("(array contains #{items['type']}s)") }
+        doc.dl(:class => "items") do
+          doc.dt(:class => "name") { doc.text("(array contains #{items['type']}s)") }
           if items.has_key?('description')
             doc.dd { doc.text(items['description']) }
           end
@@ -63,7 +63,7 @@ module Interpol
       def render_properties(doc, properties)
         return if properties.none?
 
-        doc.dl(class: "properties") do
+        doc.dl(:class => "properties") do
           properties.each do |name, property|
             property_definition(doc, name, property)
           end
@@ -71,7 +71,7 @@ module Interpol
       end
 
       def property_definition(doc, name, property)
-        doc.dt(class: "name") { doc.text(property_title name, property) }  if name
+        doc.dt(:class => "name") { doc.text(property_title name, property) }  if name
 
         if property.has_key?('description')
           doc.dd { doc.text(property['description']) }

--- a/lib/interpol/documentation_app.rb
+++ b/lib/interpol/documentation_app.rb
@@ -15,7 +15,7 @@ module Interpol
     def render_static_page(&block)
       require 'rack/mock'
       app = build(&block)
-      status, headers, body = app.call(Rack::MockRequest.env_for "/", method: "GET")
+      status, headers, body = app.call(Rack::MockRequest.env_for "/", :method => "GET")
       AssetInliner.new(body.join, app.public_folder).standalone_page
     end
 
@@ -36,13 +36,13 @@ module Interpol
 
       def inline_stylesheets
         @doc.css("link[rel=stylesheet]").map do |link|
-          inline_asset link, "style", link['href'], type: "text/css"
+          inline_asset link, "style", link['href'], :type => "text/css"
         end
       end
 
       def inline_javascript
         @doc.css("script[src]").each do |script|
-          inline_asset script, "script", script['src'], type: "text/javascript"
+          inline_asset script, "script", script['src'], :type => "text/javascript"
         end
       end
 
@@ -93,7 +93,8 @@ module Interpol
           helpers Helpers
 
           get('/') do
-            erb :layout, locals: { endpoints: endpoints, current_endpoint: current_endpoint }
+            erb :layout, :locals => { :endpoints => endpoints, \
+                                      :current_endpoint => current_endpoint }
           end
         end
       end

--- a/lib/interpol/documentation_app/views/layout.erb
+++ b/lib/interpol/documentation_app/views/layout.erb
@@ -56,7 +56,7 @@
         </div><!--/span-->
 
         <% endpoints.each do |endpoint| %>
-          <%= erb :endpoint, locals: { endpoint: endpoint, visible: (endpoint == current_endpoint) } %>
+          <%= erb :endpoint, :locals => { :endpoint => endpoint, :visible => (endpoint == current_endpoint) } %>
         <% end %>
       </div><!--/row-->
       <hr>

--- a/lib/interpol/stub_app.rb
+++ b/lib/interpol/stub_app.rb
@@ -34,9 +34,9 @@ module Interpol
         @app = Sinatra.new do
           set            :interpol_config, config
           helpers        Helpers
-          not_found      { JSON.dump(error: "The requested resource could not be found") }
+          not_found      { JSON.dump(:error => "The requested resource could not be found") }
           before         { content_type "application/json;charset=utf-8" }
-          get('/__ping') { JSON.dump(message: "Interpol stub app running.") }
+          get('/__ping') { JSON.dump(:message => "Interpol stub app running.") }
         end
       end
 

--- a/spec/fast_spec_helper.rb
+++ b/spec/fast_spec_helper.rb
@@ -50,7 +50,7 @@ RSpec.configure do |c|
   c.treat_symbols_as_metadata_keys_with_true_values = true
   c.filter_run :f
   c.run_all_when_everything_filtered = true
-  c.debug = (RUBY_ENGINE == 'ruby' && RUBY_VERSION == '1.9.3' && !ENV['CI'])
+  c.debug = defined?(RUBY_ENGINE) && RUBY_ENGINE == 'ruby' && RUBY_VERSION == '1.9.3' && !ENV['CI']
   c.include TestHelpers
   c.extend TestHelpers::ClassMethods
 

--- a/spec/simplecov_setup.rb
+++ b/spec/simplecov_setup.rb
@@ -1,4 +1,4 @@
-if RUBY_ENGINE == 'ruby' # MRI only
+if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'ruby' # MRI only
   require 'simplecov'
 
   SimpleCov.start do

--- a/spec/unit/interpol/configuration_spec.rb
+++ b/spec/unit/interpol/configuration_spec.rb
@@ -25,13 +25,13 @@ module Interpol
       end
 
       it 'finds a matching endpoint definition'  do
-        found = find(method: 'POST', path: '/foo/bar', version: '2.3')
+        found = find(:method => 'POST', :path => '/foo/bar', :version => '2.3')
         found.endpoint.should be(endpoint_2)
         found.version.should eq('2.3')
       end
 
       it 'finds the correct versioned definition of the endpoint' do
-        found = find(method: 'POST', path: '/foo/bar', version: '2.7')
+        found = find(:method => 'POST', :path => '/foo/bar', :version => '2.7')
         found.version.should eq('2.7')
       end
 
@@ -45,17 +45,17 @@ module Interpol
       end
 
       it 'returns NoDefinitionFound if it cannot find a matching route' do
-        result = find(method: 'POST', path: '/goo/bar', version: '2.7')
+        result = find(:method => 'POST', :path => '/goo/bar', :version => '2.7')
         result.should be(DefinitionFinder::NoDefinitionFound)
       end
 
       it 'returns nil if the endpoint does not have a matching version' do
-        result = find(method: 'POST', path: '/foo/bar', version: '13.7')
+        result = find(:method => 'POST', :path => '/foo/bar', :version => '13.7')
         result.should be(DefinitionFinder::NoDefinitionFound)
       end
 
       it 'handles route params properly' do
-        found = find(method: 'GET', path: '/users/17/overview', version: '1.3')
+        found = find(:method => 'GET', :path => '/users/17/overview', :version => '1.3')
         found.endpoint.should be(endpoint_1)
       end
     end
@@ -217,12 +217,12 @@ module Interpol
 
       context 'when configured with a block' do
         it "returns the blocks's return value" do
-          config.api_version { |e| e[:path][%r|/api/v(\d+)/|, 1] }
-          config.api_version_for({ path: "/api/v2/foo" }, stub.as_null_object).should eq('2')
+          config.api_version { |e, _| e[:path][%r|/api/v(\d+)/|, 1] }
+          config.api_version_for({ :path => "/api/v2/foo" }, stub.as_null_object).should eq('2')
         end
 
         it 'always returns a string, even when configured as a string' do
-          config.api_version { |e| 3 }
+          config.api_version { |_| 3 }
           config.api_version_for({}, stub.as_null_object).should eq('3')
         end
       end

--- a/spec/unit/interpol/documentation_spec.rb
+++ b/spec/unit/interpol/documentation_spec.rb
@@ -61,22 +61,22 @@ module Interpol
       end
 
       it 'renders properties' do
-        parsed_html.css("#{root_properties_dom} > .name").map(&:content).should eq([
+        parsed_html.css("#{root_properties_dom} > .name").map(&:content).should =~ [
           "first_name (string)",
           "last_name (string)",
           "date_of_birth (date)",
           "gender (string)",
           "address (object)"
-        ])
+        ]
       end
 
       it 'renders nested properties' do
-        parsed_html.css('.properties .properties .name').map(&:content).should eq([
+        parsed_html.css('.properties .properties .name').map(&:content).should =~ [
           "street (string)",
           "city (string)",
           "state (string)",
           "zip (string)"
-        ])
+        ]
       end
     end
 

--- a/spec/unit/interpol/response_schema_validator_spec.rb
+++ b/spec/unit/interpol/response_schema_validator_spec.rb
@@ -9,7 +9,7 @@ module Interpol
 
     def configuration
       lambda do |config|
-        config.stub(endpoints: definition_finder)
+        config.stub(:endpoints => definition_finder)
         config.api_version '1.0' unless api_version_configured?(config)
         config.validate_if(&validate_if_block) if validate_if_block
         config.validation_mode = validation_mode
@@ -27,7 +27,7 @@ module Interpol
     end
 
     let(:closable_body) do
-      stub(close: nil).tap do |s|
+      stub(:close => nil).tap do |s|
         s.stub(:each).and_yield('{"a":"b"}')
       end
     end
@@ -68,12 +68,12 @@ module Interpol
       end
     end
 
-    let(:validator) { fire_double("Interpol::EndpointDefinition", validate_data!: nil) }
+    let(:validator) { fire_double("Interpol::EndpointDefinition", :validate_data! => nil) }
     let(:endpoint)  { new_endpoint }
     let(:default_definition_finder) { fire_double("Interpol::DefinitionFinder") }
 
     def stub_lookup(v = validator)
-      default_definition_finder.stub(find_definition: v)
+      default_definition_finder.stub(:find_definition => v)
     end
 
     it 'validates the data against the correct versioned endpoint definition' do
@@ -100,7 +100,7 @@ module Interpol
     end
 
     it 'calls the api_version callback with the rack env and the endpoint' do
-      endpoint.stub(method: :get, route_matches?: true)
+      endpoint.stub(:method => :get, :route_matches? => true)
       self.definition_finder = [endpoint].extend(Interpol::DefinitionFinder)
 
       yielded_args = nil

--- a/spec/unit/interpol/stub_app_spec.rb
+++ b/spec/unit/interpol/stub_app_spec.rb
@@ -27,10 +27,10 @@ module Interpol
 
     let(:app) do
       StubApp.build do |config|
-        config.stub(endpoints: [endpoint])
+        config.stub(:endpoints => [endpoint])
 
         unless api_version_configured?(config) # allow default config to take precedence
-          config.api_version { |env| env.fetch('HTTP_API_VERSION') }
+          config.api_version { |env, _| env.fetch('HTTP_API_VERSION') }
         end
       end.tap do |a|
         a.set :raise_errors, true
@@ -73,7 +73,7 @@ module Interpol
 
     it 'uses the unavailable_request_version hook when an invalid version is requested' do
       app.interpol_config.on_unavailable_request_version do |requested_version, available_versions|
-        halt 405, JSON.dump(requested: requested_version, available: available_versions)
+        halt 405, JSON.dump(:requested => requested_version, :available => available_versions)
       end
 
       header 'API-Version', '2.0'


### PR DESCRIPTION
Hash syntax converted by hash_syntax gem, nice.

Fixed some specs related to order: the data comes from a hash
so fundamentally doesn't have order; the specs
were dependening on whatever random order Ruby 1.9 happened to use.

Syck doesn't through an error on YAML with missing anchors, instead
there are YAML::Syck::\* objects in the resulting yaml.
