### PR TITLE
Add Hashie Mash to Gemfile

### DIFF
--- a/example/Gemfile
+++ b/example/Gemfile
@@ -1,8 +1,9 @@
 source 'https://rubygems.org'
 
+gem 'hashie', '~> 2.0.5'
+gem 'interpol', :path => '..'
+gem 'multi_json', '~> 1.2.0'
+gem 'rake', '~> 0.9.2.2'
 gem 'rspec', '~> 2.9'
 gem 'sinatra', '~> 1.3'
-gem 'rake', '~> 0.9.2.2'
-gem 'multi_json', '~> 1.2.0'
-gem 'interpol', :path => '..'
 


### PR DESCRIPTION
When I tried to run the example app I received an error that hashie mash was not found.
- Added `hashie` to example app Gemfile
- Sorted gemfile alphabetically
