### PR TITLE
Explicitly require json

### DIFF
--- a/lib/interpol/endpoint.rb
+++ b/lib/interpol/endpoint.rb
@@ -1,6 +1,7 @@
-require 'json-schema'
-require 'interpol/errors'
 require 'forwardable'
+require 'interpol/errors'
+require 'json'
+require 'json-schema'
 require 'set'
 
 module JSON


### PR DESCRIPTION
Was receiving this error when running the example app test suite:

``` terminal
Failures:

  1) API Examples add_contact_address (v 2.0) has valid data for example 1
     Failure/Error: define_test(description) { example.validate! }
     NoMethodError:
       undefined method `parse' for JSON:Module
     # /Users/harlow/opensource/interpol/lib/interpol/endpoint.rb:39:in `open'
```
- Added `json` require
- Sorted require statements alphabetically
