### PR TITLE
Don't mutate the input schema when making the schema strict.

### DIFF
--- a/lib/interpol/endpoint.rb
+++ b/lib/interpol/endpoint.rb
@@ -195,7 +195,7 @@ module Interpol
       @message_type    = message_type
       @status_codes    = StatusCodeMatcher.new(definition['status_codes'])
       @version         = version
-      @schema          = fetch_from(definition, 'schema')
+      @schema          = Marshal.load(Marshal.dump fetch_from(definition, 'schema'))
       @path_params     = definition.fetch('path_params', DEFAULT_PARAM_HASH.dup)
       @query_params    = definition.fetch('query_params', DEFAULT_PARAM_HASH.dup)
       @examples        = extract_examples_from(definition)

--- a/spec/unit/interpol/endpoint_spec.rb
+++ b/spec/unit/interpol/endpoint_spec.rb
@@ -311,6 +311,17 @@ module Interpol
       end
     end
 
+    it 'does not mutate the given schema when making it strict' do
+      new_basic_schema = lambda { {
+        'type'       => 'object',
+        'properties' => {'foo' => { 'type' => 'integer' } }
+      } }
+
+      schema = new_basic_schema.call
+      EndpointDefinition.new(endpoint, version, 'response', build_hash('schema' => schema))
+      expect(schema).to eq(new_basic_schema.call)
+    end
+
     describe "#validate_data" do
       let(:schema) do {
         'type'       => 'object',


### PR DESCRIPTION
This was causing a problem with an endpoint definition that listed
multiple versions, as the same schema got made strict multiple times.
