### PR TITLE
Documentation dependency on Nokogiri is not picked up by Bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,3 @@ gem 'compass_twitter_bootstrap', :git => 'git://github.com/vwall/compass-twitter
 gem 'json', :platform => 'ruby_18'
 
 gem 'cane', '~> 2.6' if RUBY_VERSION.to_f > 1.8
-
-# 1.6 won't install on JRuby or 1.8.7 :(.
-gem 'nokogiri', '~> 1.5.10'
-

--- a/interpol.gemspec
+++ b/interpol.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'rack'
   gem.add_dependency 'json-schema', '~> 1.1.1'
+  gem.add_dependency 'nokogiri', '~> 1.5.10' # 1.6 won't install on JRuby or 1.8.7 :(.
 
   gem.add_development_dependency 'rspec', '~> 2.13'
   gem.add_development_dependency 'rspec-fire', '~> 1.2'


### PR DESCRIPTION
:information_desk_person: The Nokogiri dependency in this project's Gemfile does not appear to be picked up by Bundler when running the documentation app, causing a LoadError exception to be raised. Moving the dependency into the gemspec as a runtime dependency resolves this issue.

I've added some more information around this issue below (Ruby version 2.1.1, Bundler version 1.6.2, Interpol version 0.10.6).

My Gemfile:

``` ruby
source "https://rubygems.org"

gem "interpol", "0.10.6"
gem "sinatra"
```

```
$ bundle install
Resolving dependencies...
Using json-schema 1.1.1
Using rack 1.5.2
Using interpol 0.10.6
Using rack-protection 1.5.3
Using tilt 1.4.1
Using sinatra 1.4.5
Using bundler 1.6.2
Your bundle is complete!
Use `bundle show [gemname]` to see where a bundled gem is installed.
```

My example documentation app:

``` ruby
# doc_app.ru 
require 'interpol/documentation_app'
require 'sinatra'

doc_app = Interpol::DocumentationApp.build

run doc_app
```

```
bundle exec rackup doc_app.ru 
/Users/sg/.gem/ruby/2.1.1/gems/interpol-0.10.6/lib/interpol/documentation.rb:1:in `require': cannot load such file -- nokogiri (LoadError)
    from /Users/sg/.gem/ruby/2.1.1/gems/interpol-0.10.6/lib/interpol/documentation.rb:1:in `<top (required)>'
    from /Users/sg/.gem/ruby/2.1.1/gems/interpol-0.10.6/lib/interpol/documentation_app.rb:2:in `require'
    from /Users/sg/.gem/ruby/2.1.1/gems/interpol-0.10.6/lib/interpol/documentation_app.rb:2:in `<top (required)>'
    from /Users/sg/src/presentations/Twilio/working-with-apis-for-fun-and-profit/doc_app.ru:1:in `require'
    from /Users/sg/src/presentations/Twilio/working-with-apis-for-fun-and-profit/doc_app.ru:1:in `block in <main>'
    from /usr/local/rubies/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/builder.rb:55:in `instance_eval'
    from /usr/local/rubies/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/builder.rb:55:in `initialize'
    from /Users/sg/src/presentations/Twilio/working-with-apis-for-fun-and-profit/doc_app.ru:in `new'
    from /Users/sg/src/presentations/Twilio/working-with-apis-for-fun-and-profit/doc_app.ru:in `<main>'
    from /usr/local/rubies/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/builder.rb:49:in `eval'
    from /usr/local/rubies/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/builder.rb:49:in `new_from_string'
    from /usr/local/rubies/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/builder.rb:40:in `parse_file'
    from /usr/local/rubies/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/server.rb:277:in `build_app_and_options_from_config'
    from /usr/local/rubies/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/server.rb:199:in `app'
    from /usr/local/rubies/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/server.rb:314:in `wrapped_app'
    from /usr/local/rubies/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/server.rb:250:in `start'
    from /usr/local/rubies/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/server.rb:141:in `start'
    from /usr/local/rubies/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/bin/rackup:4:in `<top (required)>'
    from /Users/sg/.rbenv/versions/ruby-2.1.1/bin/rackup:23:in `load'
    from /Users/sg/.rbenv/versions/ruby-2.1.1/bin/rackup:23:in `<main>'
```
