### PR TITLE
Base Path Config (WIP)

### DIFF
--- a/interpol.gemspec
+++ b/interpol.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'rack'
   gem.add_dependency 'json-schema', '~> 2.2.5'
-  gem.add_dependency 'hashie', '~> 1.2'
+  gem.add_dependency 'hashie', '>= 1.2'
 
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'simplecov', '~> 0.6'
@@ -28,4 +28,3 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rack-test', '0.6.1'
   gem.add_development_dependency 'sinatra', '~> 1.4'
 end
-

--- a/lib/interpol/configuration.rb
+++ b/lib/interpol/configuration.rb
@@ -36,18 +36,23 @@ module Interpol
   # Public: Defines interpol configuration.
   class Configuration
     attr_reader :endpoint_definition_files, :endpoints, :filter_example_data_blocks,
-                :endpoint_definition_merge_key_files
+                :endpoint_definition_merge_key_files, :base_path
     attr_accessor :validation_mode, :documentation_title
 
     def initialize
       self.endpoint_definition_files = []
       self.endpoint_definition_merge_key_files = []
+      self.base_path = ''
       self.documentation_title = "API Documentation Provided by Interpol"
       register_default_callbacks
       register_built_in_param_parsers
       @filter_example_data_blocks = []
 
       yield self if block_given?
+    end
+
+    def base_path=(path)
+      @base_path = path
     end
 
     def endpoint_definition_files=(files)
@@ -259,6 +264,7 @@ module Interpol
   # Holds the validation/parsing logic for a particular parameter
   # type (w/ additional options).
   class ParamParser
+    attr_reader :type, :options
     def initialize(type, options = {})
       @type = type
       @options = options
@@ -302,4 +308,3 @@ module Interpol
     end
   end
 end
-

--- a/lib/interpol/request_body_validator.rb
+++ b/lib/interpol/request_body_validator.rb
@@ -65,9 +65,10 @@ module Interpol
       end
 
       def endpoint_definition(&block)
-        config.endpoints.find_definition(request_method, path, 'request', nil) do |endpoint|
-          available = endpoint.available_request_versions
+        rel_path = path.gsub(config.base_path, '')
 
+        config.endpoints.find_definition(request_method, rel_path, 'request', nil) do |endpoint|
+          available = endpoint.available_request_versions
           @config.request_version_for(env, endpoint).tap do |requested|
             unless available.include?(requested)
               yield @config.request_version_unavailable(env, requested, available)
@@ -79,4 +80,3 @@ module Interpol
     end
   end
 end
-

--- a/lib/interpol/response_schema_validator.rb
+++ b/lib/interpol/response_schema_validator.rb
@@ -65,7 +65,7 @@ module Interpol
       end
 
       def path
-        env.fetch('PATH_INFO')
+        env.fetch('PATH_INFO').gsub(config.base_path, '')
       end
 
       def validator
@@ -91,4 +91,3 @@ module Interpol
     end
   end
 end
-

--- a/lib/interpol/sinatra/request_params_parser.rb
+++ b/lib/interpol/sinatra/request_params_parser.rb
@@ -92,8 +92,10 @@ module Interpol
         def endpoint_definition
           version = available_versions = nil
 
+          rel_path = request.path.gsub(config.base_path,'')
+
           definition = config.endpoints.find_definition \
-            request.env.fetch('REQUEST_METHOD'), request.path, 'request', nil do |endpoint|
+            request.env.fetch('REQUEST_METHOD'), rel_path, 'request', nil do |endpoint|
               available_versions ||= endpoint.available_request_versions
               config.request_version_for(request.env, endpoint).tap do |_version|
                 version ||= _version
@@ -170,4 +172,3 @@ module Interpol
     end
   end
 end
-


### PR DESCRIPTION
[Barbosa](https://github.com/seomoz/barbosa), the new ose api, uses interpol. Previously, we were using versions (in the url) as designed meaning you could have different versions for every endpoint and their request/response. However, a couple of factors recently encouraged us to switch to a global version; [you can see that switch here](https://github.com/seomoz/barbosa/commit/3cf37719b3b44845164d9ab6bab2f4fdc6fd1449).

In order for this to work like we wish, it seemed to me I needed to be able to introduce a `base_path` config value for interpol. By doing this, I can [set a base path](https://github.com/seomoz/barbosa/commit/3cf37719b3b44845164d9ab6bab2f4fdc6fd1449#diff-f6e30280bf8a0db0c1c9e2c6638cff84R9) once, have my endpoint definitions [be independent of the base path (and version)](https://github.com/seomoz/barbosa/commit/3cf37719b3b44845164d9ab6bab2f4fdc6fd1449#diff-1b8cb85b003986c7f3c037e4abda8ba4L3) and allowing me to [bump the version in 1 place](https://github.com/seomoz/barbosa/commit/3cf37719b3b44845164d9ab6bab2f4fdc6fd1449#diff-8b9d03964a047d46c2a3344aced0309aR1).

This is no the whole story but I hope the highlights are enough to describe our need for this `base_path` config.
